### PR TITLE
feat: add strategy option to get_account_transactions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "enablebanking_sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["NOCFO <team@nocfo.io>"]
 license = "MIT"

--- a/src/enablebanking_sdk/constants/__init__.py
+++ b/src/enablebanking_sdk/constants/__init__.py
@@ -3,3 +3,4 @@ from .address_type import *
 from .authentication_approach import *
 from .psu_type import *
 from .scheme_name import *
+from .transaction_fetch_strategy import *

--- a/src/enablebanking_sdk/constants/transaction_fetch_strategy.py
+++ b/src/enablebanking_sdk/constants/transaction_fetch_strategy.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class TransactionsFetchStrategy(StrEnum):
+    DEFAULT = "default"
+    LONGEST = "longest"

--- a/src/enablebanking_sdk/service/integration.py
+++ b/src/enablebanking_sdk/service/integration.py
@@ -6,6 +6,7 @@ from requests.exceptions import HTTPError
 import jwt
 import requests
 
+from ..constants.transaction_fetch_strategy import TransactionsFetchStrategy
 from ..exceptions import EnableBankingException
 
 
@@ -139,6 +140,7 @@ class EnableBankingIntegration:
         account_uid: str,
         date_from: datetime | None = None,
         date_to: datetime | None = None,
+        strategy: TransactionsFetchStrategy | None = None,
         psu_headers: dict | None = None,
         continuation_key: str | None = None,
     ) -> dict:
@@ -152,6 +154,7 @@ class EnableBankingIntegration:
             params={
                 "date_from": _fmt_dt(date_from),
                 "date_to": _fmt_dt(date_to),
+                "strategy": strategy,
                 "continuation_key": continuation_key,
             },
         )

--- a/src/enablebanking_sdk/service/service.py
+++ b/src/enablebanking_sdk/service/service.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 
 from ..constants import PSUType
+from ..constants.transaction_fetch_strategy import TransactionsFetchStrategy
 from ..models import (
     AspspData,
     EnableBankingStartAuthorizationRequest,
@@ -79,6 +80,7 @@ class EnableBankingService:
         account_uid: str,
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
+        strategy: Optional[TransactionsFetchStrategy] = None,
         psu_headers: Optional[dict] = None,
     ) -> list[Transaction]:
         transactions = []
@@ -89,6 +91,7 @@ class EnableBankingService:
                 account_uid=account_uid,
                 date_from=date_from,
                 date_to=date_to,
+                strategy=strategy,
                 psu_headers=psu_headers,
                 continuation_key=continuation_key,
             )

--- a/tests/test_enablebanking_service.py
+++ b/tests/test_enablebanking_service.py
@@ -3,7 +3,8 @@ from datetime import date, datetime
 from unittest import mock
 
 from src.enablebanking_sdk.constants import PSUType
-from src.enablebanking_sdk.models import AspspData
+from src.enablebanking_sdk.constants.transaction_fetch_strategy import TransactionsFetchStrategy
+from src.enablebanking_sdk.models import AspspData, Transaction
 from src.enablebanking_sdk.service import EnableBankingService, EnableBankingIntegration
 from tests.utils import get_json_fixtures
 
@@ -87,6 +88,7 @@ class EnableBankingServiceTest(unittest.TestCase):
                 date(2024, 1, 1),
                 datetime.min.time(),
             ),
+            strategy=TransactionsFetchStrategy.DEFAULT,
             psu_headers={"test_header": "test_value"},
         )
 


### PR DESCRIPTION
Adds the strategy field to the get_account_transactions method.

Docs: [API method](https://enablebanking.com/docs/api/reference/#get-account-transactions) / [Enum](https://enablebanking.com/docs/api/reference/#transactionsfetchstrategy).