### PR TITLE
feat: Add account details method

### DIFF
--- a/src/enablebanking_sdk/models/aspsp.py
+++ b/src/enablebanking_sdk/models/aspsp.py
@@ -84,6 +84,7 @@ class EnableBankingAccount(BaseModel):
     cash_account_type: str
     account_id: Optional[EnableBankingAccountIdentification] = Field(default=None)
     name: Optional[str] = Field(default=None)
+    details: Optional[str] = Field(default=None)
 
 
 class EnableBankingAuthorizeSessionResponse(BaseModel):

--- a/src/enablebanking_sdk/service/integration.py
+++ b/src/enablebanking_sdk/service/integration.py
@@ -169,3 +169,14 @@ class EnableBankingIntegration:
             path=f"/accounts/{account_uid}/balances",
             headers=psu_headers,
         )
+
+    def get_account_details(
+        self,
+        account_uid: str,
+        psu_headers: dict | None = None,
+    ) -> dict:
+        return self._request(
+            method="GET",
+            path=f"/accounts/{account_uid}/details",
+            headers=psu_headers,
+        )

--- a/src/enablebanking_sdk/service/service.py
+++ b/src/enablebanking_sdk/service/service.py
@@ -13,6 +13,7 @@ from ..models import (
     AspspsResponse,
     EnableBankingAccess,
     AccountBalances,
+    EnableBankingAccount,
 )
 from .integration import EnableBankingIntegration
 
@@ -113,3 +114,14 @@ class EnableBankingService:
             psu_headers=psu_headers,
         )
         return AccountBalances.parse_obj(data)
+
+    def get_account_details(
+        self,
+        account_uid: str,
+        psu_headers: Optional[dict] = None,
+    ) -> EnableBankingAccount:
+        data = self.integration.get_account_details(
+            account_uid=account_uid,
+            psu_headers=psu_headers,
+        )
+        return EnableBankingAccount.parse_obj(data)

--- a/tests/fixture/account_details_response.json
+++ b/tests/fixture/account_details_response.json
@@ -1,0 +1,30 @@
+{
+  "account_id": {
+    "iban": "FI2439390058811110",
+    "other": null
+  },
+  "all_account_ids": [
+    {
+      "identification": "FI2439390058811110",
+      "scheme_name": "IBAN",
+      "issuer": null
+    }
+  ],
+  "account_servicer": null,
+  "name": "MAKKONEN MARJA-LIISA",
+  "details": "My account nickname",
+  "usage": "PRIV",
+  "cash_account_type": "CACC",
+  "product": "TESTITILI",
+  "currency": "EUR",
+  "psu_status": null,
+  "credit_limit": null,
+  "uid": "9fd5eab6-750e-4ec1-9d28-ef8456d15023",
+  "identification_hash": "WwpbCiJhY2NvdW50IiwKImFjY291bnRfaWsdfLAoiaWJhbiIKXSwKWwoiYWNjb3VudCIsCiJjdXJyZW5jeSIKXQpd.FPgR1ZhFiDseBx1pF2nWUGLaN+mvrxcFxzcChS3GZMY=",
+  "identification_hashes": [
+    "WwpbCiJhY2NvdW50IiwKImFjY291bnRfaWQiLAoiaWJhbiIKXQpd.Y17SsdfTt/qlablPvhMlhRMnm2MsCZcs9FvQy4Syd4Do=",
+    "WwpbCiJhY2NvdW50IiwKImFjY291bnRfaWQiLAoiaWJhbiIKXSwKWwoiYsdfjb3VudCIsCiJjdXJyZW5jeSIKXQpd.FPgR1ZhFiDseBx1pF2nWUGLaN+mvrxcFxzcChS3GZMY=",
+    "WwpbCiJhc3BzcF9uYW1lIgpdLApbCiJhc3BzcF9jb3VudHJ5IgpdLApbCiJhY2NvdW50IiwKInJlc291cmNlX2lkIgpdsdf0=.cXjsruuvM5LOzK7xYgXEryJqhYKuSk7BCwkbAqZUnCw=",
+    "WwpbCiJhc3BzcF9uYW1lIgpdLApbCiJhc3BzcF9jb3VudHJ5IgpdLApbCasd2NvdW50IiwKIm5hbWUiCl0KXQ==.SRwCm0RIBT0AFY/Ld/M67GI6cADRlr/iuZRbVaN0S6c="
+  ]
+}

--- a/tests/test_enablebanking_service.py
+++ b/tests/test_enablebanking_service.py
@@ -111,3 +111,16 @@ class EnableBankingServiceTest(unittest.TestCase):
         self.assertEqual(len(data.balances), 2)
         self.assertEqual(data.balances[0].balance_amount.amount, 2107.45)
         self.assertEqual(data.balances[0].balance_amount.currency, "EUR")
+
+    @mock.patch.object(EnableBankingIntegration, "_request")
+    def test_get_account_details(self, request_mock):
+        request_mock.side_effect = get_json_fixtures(
+            "account_details_response.json",
+        )
+
+        data = self.service.get_account_details(
+            "account_uid",
+            psu_headers={"test_header": "test_value"},
+        )
+
+        self.assertEqual(data.details, "My account nickname")


### PR DESCRIPTION
https://enablebanking.com/docs/api/reference/#get-account-details

Adds account details method + `details` attribute in `EnableBankingAccount`.